### PR TITLE
feat: Support graceful shutdown with possible delayed pod termination…

### DIFF
--- a/horizon-starlight/templates/deployment.yaml
+++ b/horizon-starlight/templates/deployment.yaml
@@ -72,6 +72,9 @@ spec:
           {{- end }}
           env: {{- include "horizon.starlight.envs" . | nindent 12 }}
       {{- with .Values.volumes }}
+      {{ if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/horizon-starlight/values.yaml
+++ b/horizon-starlight/values.yaml
@@ -121,11 +121,9 @@ startupProbe:
   failureThreshold: 75
 
 lifecycle:
-#  preStop:
-#    httpGet:
-#      path: /actuator/shutdown
-#      port: actuator
-#      scheme: HTTP
+  #preStop:
+  #  exec:
+  #    command: ["sleep", "15"]
 
 # -- Horizontal Pod Autoscaler configuration.
 autoscaling:
@@ -172,6 +170,9 @@ monitoring:
       - developer.telekom.de/team
       - developer.telekom.de/environment
       - app
+
+# -- Termination grace period (in seconds) for the pod. We set a default value of 45 seconds because commonHorizon.publishingTimeoutMs is set to 45000 milliseconds.
+terminationGracePeriodSeconds: 45
 
 # -- Custom environment variables
 customEnv: {}


### PR DESCRIPTION
… in k8s

- Set terminationGracePeriod to 45 seconds as kafka producing timout is 45 seconds