### PR TITLE
Update horizon-all parent chart depencencies to point to new/next release version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<!-- 
+Copyright 2025 Deutsche Telekom IT GmbH
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # 1.0.0 (2025-06-18)
 
 

--- a/release.config.js
+++ b/release.config.js
@@ -19,7 +19,7 @@ module.exports = {
     '@semantic-release/release-notes-generator',
     '@semantic-release/changelog',
     ['@semantic-release/exec', {
-      prepareCmd: 'node scripts/update-all-chart-versions.js ${nextRelease.version}'
+      prepareCmd: 'node scripts/update-all-chart-versions.js ${nextRelease.version} && node scripts/update-parent-chart-dependencies.js ${nextRelease.version}'
     }],
     ['@semantic-release/git', {
       assets: ['charts/**/Chart.yaml', 'CHANGELOG.md'],

--- a/release.config.js
+++ b/release.config.js
@@ -19,7 +19,11 @@ module.exports = {
     '@semantic-release/release-notes-generator',
     '@semantic-release/changelog',
     ['@semantic-release/exec', {
-      prepareCmd: 'node scripts/update-all-chart-versions.js ${nextRelease.version} && node scripts/update-parent-chart-dependencies.js ${nextRelease.version}'
+      prepareCmd: `
+        node scripts/update-horizon-all-versions.js \${nextRelease.version} &&
+        node scripts/update-parent-chart-dependencies.js \${nextRelease.version} &&
+        node scripts/prepend-changelog-license.js
+      `
     }],
     ['@semantic-release/git', {
       assets: ['charts/**/Chart.yaml', 'CHANGELOG.md'],

--- a/scripts/prepend-changelog-license.js
+++ b/scripts/prepend-changelog-license.js
@@ -1,0 +1,32 @@
+// Copyright 2025 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+const fs = require('fs');
+const path = require('path');
+
+const changelogPath = path.resolve(__dirname, '../CHANGELOG.md');
+const spdxHeader = `<!--
+Copyright 2025 Deutsche Telekom IT GmbH
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+`;
+
+if (!fs.existsSync(changelogPath)) {
+    console.warn('⚠️ WARNING: CHANGELOG.md not found, skipping SPDX header prepend.');
+    process.exit(0);
+}
+
+const currentContent = fs.readFileSync(changelogPath, 'utf8');
+
+const spdxRegex = /^<!--\s*Copyright [0-9]{4} Deutsche Telekom IT GmbH/m;
+
+if (!spdxRegex.tegst(currentContent)) {
+  const updatedContent = spdxHeader + currentContent;
+  fs.writeFileSync(changelogPath, updatedContent, 'utf8');
+  console.log('✅ Prepended SPDX header to CHANGELOG.md');
+} else {
+  console.log('ℹ️ SPDX header already present in CHANGELOG.md');
+}

--- a/scripts/update-all-chart-versions.js
+++ b/scripts/update-all-chart-versions.js
@@ -4,19 +4,29 @@
 
 const fs = require('fs');
 const path = require('path');
+const yaml = require('js-yaml');
 
 const version = process.argv[2];
+
+if (!version) {
+  console.error('❌ Error: You must provide a version (e.g. `node update-all-chart-versions.js 1.2.3`)');
+  process.exit(1);
+}
+
 const chartsDir = path.resolve(__dirname, '../charts');
 
 const charts = fs.readdirSync(chartsDir).filter(dir => {
-  const chartYaml = path.join(chartsDir, dir, 'Chart.yaml');
-  return fs.existsSync(chartYaml);
+  const chartYamlPath = path.join(chartsDir, dir, 'Chart.yaml');
+  return fs.existsSync(chartYamlPath);
 });
 
 charts.forEach(chart => {
   const chartPath = path.join(chartsDir, chart, 'Chart.yaml');
-  const yaml = fs.readFileSync(chartPath, 'utf8');
-  const updated = yaml.replace(/^version: .*/m, `version: ${version}`);
-  fs.writeFileSync(chartPath, updated);
+  const chartContent = yaml.load(fs.readFileSync(chartPath, 'utf8'));
+
+  // Update the version
+  chartContent.version = version;
+
+  fs.writeFileSync(chartPath, yaml.dump(chartContent, { lineWidth: -1 }), 'utf8');
   console.log(`✅ Updated ${chart}/Chart.yaml to version ${version}`);
 });

--- a/scripts/update-parent-chart-dependencies.js
+++ b/scripts/update-parent-chart-dependencies.js
@@ -1,0 +1,34 @@
+// Copyright 2025 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const version = process.argv[2];
+
+if (!version) {
+  console.error('❌ Error: You must provide a version, e.g. `node update-horizon-all-versions.js 1.2.3`');
+  process.exit(1);
+}
+
+const chartPath = path.resolve(__dirname, '../horizon-all/Chart.yaml');
+
+if (!fs.existsSync(chartPath)) {
+  console.error('❌ horizon-all/Chart.yaml not found');
+  process.exit(1);
+}
+
+const chart = yaml.load(fs.readFileSync(chartPath, 'utf8'));
+
+// Update all dependency versions
+if (Array.isArray(chart.dependencies)) {
+  chart.dependencies.forEach(dep => {
+    dep.version = version;
+  });
+}
+
+fs.writeFileSync(chartPath, yaml.dump(chart, { lineWidth: -1 }), 'utf8');
+
+console.log(`✅ Updated horizon-all/Chart.yaml and all dependencies to version ${version}`);


### PR DESCRIPTION
With this change the workflow has been improved to also update the dependency versions in the horizon-all parent Helm chart.